### PR TITLE
Changed ranges of i in preprocess.binarize to get the right bins

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -18,15 +18,15 @@ def binarize(matrix, attributes, bins=4):
             binned_attributes.append(att)
             target_values = []
             for i, _ in enumerate(edges):
-                lower, upper = str(edges[i-1]), str(edges[i])
-                target_values.append('{}=<{}<{}'.format(lower,att,upper))
+                lower, upper = str(edges[i]), str(edges[(i + 1) % len(edges)])
+                target_values.append('{}<={}<{}'.format(lower,att,upper))
 
             for j, bin_idx in enumerate(membership):
                 binarized_data[j].append(target_values[bin_idx-1])
         else:
-            for i, _ in enumerate(edges):
-                lower, upper = str(edges[i-1]), str(edges[i])
-                binned_attributes.append('{}=<{}<{}'.format(lower,att,upper))
+            for i in range(1, len(edges)):
+                lower, upper = str(edges[i - 1]), str(edges[i])
+                binned_attributes.append('{}<={}<{}'.format(lower,att,upper))
 
             for i, _ in enumerate(binned_attributes):
                 for j, bin_idx in enumerate(membership):


### PR DESCRIPTION
…their descriptions given in the new names of attributes

Note: I did not make any major changes in the new names of attributes, because these are not the cause of `Exception: No examples provided! Examples should be instances of http://kt.ijs.s
i/hedwig#Example.`, which is raised every time I try to use `Hedwig` through `hbp_wrapper`. (Hence, the only change in the names is that the former `=<` is now `<=`).

However, when I run `Hedwig` directly, the use of (the former or current version of) these attribute names causes a warning-like message `No handlers could be found for logger "rdflib.term"`  (which is not the case when very uninformative attribute names such as `att_<id-add>_<id-bin>` are used).

I am not completely sure that interval descriptions `[lower, upper)` of the bins are totally correct anyway: When the attribute with values from `{0.0, 0.5, 1.0}` was divided into two binary attributes `0.0<=ATT<0.5` and `0.5<=ATT<1.0`, the latter had value `1`, if originally `ATT = 0.5` (also, `1.0` is always a member of `0.5<=ATT<1.0`).
